### PR TITLE
SD-7490: Add starts_with, ends_with, contains

### DIFF
--- a/cases/string/contains.yaml
+++ b/cases/string/contains.yaml
@@ -1,0 +1,94 @@
+function: contains
+cases:
+  - group:
+      id: basic
+      description: Basic examples contains as prefix
+    args:
+      - value: 'abcdefg'
+        type: string
+      - value: 'abc'
+        type: string
+    result:
+      value: true
+      type: boolean
+  - group:
+      id: basic
+      description: Basic examples as case insensitivity
+    args:
+      - value: 'abcdefg'
+        type: string
+      - value: 'CdE'
+        type: string
+    options:
+      case_sensitivity: CASE_INSENSITIVE
+    result:
+      value: true
+      type: boolean
+  - group:
+      id: basic
+      description: Basic examples contains in middle
+    args:
+      - value: 'abcdefg'
+        type: string
+      - value: 'cde'
+        type: string
+    result:
+      value: true
+      type: boolean
+  - group:
+      id: basic
+      description: Basic examples contains as suffix
+    args:
+      - value: 'abcdefg'
+        type: string
+      - value: 'fg'
+        type: string
+    result:
+      value: true
+      type: boolean
+  - group:
+      id: basic
+      description: Basic examples missing substring
+    args:
+      - value: 'abcdefg'
+        type: string
+      - value: 'aef'
+        type: string
+    result:
+      value: false
+      type: boolean
+  - group:
+      id: multi_byte_characters
+      description: multi byte characters exists in the string
+    args:
+      - value: '😊a😊b😊😊'
+        type: string
+      - value: 'a😊b'
+        type: string
+    result:
+      value: true
+      type: boolean
+  - group:
+      id: multi_byte_characters
+      description: multi byte characters exists in the string with case insensitivity
+    args:
+      - value: '😊a😊b😊😊'
+        type: string
+      - value: 'A😊B'
+        type: string
+    options:
+      case_sensitivity: CASE_INSENSITIVE
+    result:
+      value: true
+      type: boolean
+  - group:
+      id: multi_byte_characters
+      description: multi byte characters absent in the string
+    args:
+      - value: '😊a😊b😊😊'
+        type: string
+      - value: 'a😊c'
+        type: string
+    result:
+      value: false
+      type: boolean

--- a/cases/string/ends_with.yaml
+++ b/cases/string/ends_with.yaml
@@ -1,0 +1,62 @@
+function: ends_with
+cases:
+  - group:
+      id: basic
+      description: Basic examples without any special cases
+    args:
+      - value: 'abcd'
+        type: string
+      - value: 'd'
+        type: string
+    result:
+      value: true
+      type: boolean
+  - group:
+      id: basic
+      description: Basic examples without any special case
+    args:
+      - value: 'abcd'
+        type: string
+      - value: 'a'
+        type: string
+    result:
+      value: false
+      type: boolean
+  - group:
+     id: case_insenstivity
+     description: multi byte character comparison with case insensitivity
+    args:
+      - value: 'abcd'
+        type: string
+      - value: 'CD'
+        type: string
+    options:
+      case_sensitivity: CASE_INSENSITIVE
+    result:
+      value: true
+      type: boolean
+  - group:
+     id: multi_byte_characters
+     description: multi byte character comparison
+    args:
+      - value: '😊a😊b😊😊'
+        type: string
+      - value: 'b😊😊'
+        type: string
+    result:
+      value: true
+      type: boolean
+  - group:
+     id: multi_byte_characters case insensitivity
+     description: multi byte character comparison with case insensitivity
+    args:
+      - value: '😊a😊b😊😊'
+        type: string
+      - value: 'B😊😊'
+        type: string
+    options:
+      case_sensitivity: CASE_INSENSITIVE
+    result:
+      value: true
+      type: boolean
+

--- a/cases/string/starts_with.yaml
+++ b/cases/string/starts_with.yaml
@@ -1,0 +1,62 @@
+function: starts_with
+cases:
+  - group:
+      id: basic
+      description: Basic examples without any special cases
+    args:
+      - value: 'abcd'
+        type: string
+      - value: 'a'
+        type: string
+    result:
+      value: true
+      type: boolean
+  - group:
+      id: basic
+      description: Basic examples without any special case
+    args:
+      - value: 'abcd'
+        type: string
+      - value: 'z'
+        type: string
+    result:
+      value: false
+      type: boolean
+  - group:
+     id: case_insenstivity
+     description: multi byte character comparison with case insensitivity
+    args:
+      - value: 'abcd'
+        type: string
+      - value: 'AB'
+        type: string
+    options:
+      case_sensitivity: CASE_INSENSITIVE
+    result:
+      value: true
+      type: boolean
+  - group:
+     id: multi_byte_characters
+     description: multi byte character comparison
+    args:
+      - value: '😊a😊b😊😊'
+        type: string
+      - value: '😊a'
+        type: string
+    result:
+      value: true
+      type: boolean
+  - group:
+     id: multi_byte_characters case insensitivity
+     description: multi byte character comparison with case insensitivity
+    args:
+      - value: '😊a😊b😊😊'
+        type: string
+      - value: '😊A'
+        type: string
+    options:
+      case_sensitivity: CASE_INSENSITIVE
+    result:
+      value: true
+      type: boolean
+

--- a/dialects/cudf.yaml
+++ b/dialects/cudf.yaml
@@ -220,6 +220,12 @@ scalar_functions:
     unsupported: true
   - name: string_split
     local_name: "split"
+  - name: starts_with
+    unsupported: True
+  - name: ends_with
+    unsupported: True
+  - name: contains
+    unsupported: True
   - name: ln
     local_name: log
     required_options:

--- a/dialects/datafusion.yaml
+++ b/dialects/datafusion.yaml
@@ -236,6 +236,12 @@ scalar_functions:
   - name: right
   - name: string_split
     unsupported: True
+  - name: starts_with
+    unsupported: True
+  - name: ends_with
+    unsupported: True
+  - name: contains
+    unsupported: True
   - name: ln
     required_options:
       on_log_zero: MINUS_INFINITY

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -252,6 +252,15 @@ scalar_functions:
   - name: left
   - name: right
   - name: string_split
+  - name: starts_with
+    required_options:
+      case_sensitivity: CASE_SENSITIVE
+  - name: ends_with
+    required_options:
+      case_sensitivity: CASE_SENSITIVE
+  - name: contains
+    required_options:
+      case_sensitivity: CASE_SENSITIVE
   - name: ln
     required_options:
       on_log_zero: ERROR

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -482,6 +482,13 @@ scalar_functions:
   - name: right
   - name: string_split
     unsupported: True
+  - name: starts_with
+    required_options:
+      case_sensitivity: CASE_SENSITIVE
+  - name: ends_with
+    unsupported: True
+  - name: contains
+    unsupported: True
   - name: ln
     required_options:
       on_log_zero: ERROR

--- a/dialects/snowflake.yaml
+++ b/dialects/snowflake.yaml
@@ -195,6 +195,9 @@ scalar_functions:
   - name: gte_datetime
     unsupported: True
   - name: substring
+    #unsupported because Sf returns number of UTF-8 characters substring('😊a😊b😊😊', 1, 3)
+    #required_options:
+      #negative_start: WRAP_FROM_END
     unsupported: True
   - name: concat
     local_name: "||"
@@ -229,11 +232,24 @@ scalar_functions:
   - name: lpad
   - name: rpad
   - name: left
+    #unsupported because Sf returns number of UTF-8 characters for Left('😔😄😔😄', 2)
     unsupported: True
   - name: right
+    #unsupported because Sf returns number of UTF-8 characters for Right('😔😄😔😄', 2)
     unsupported: True
   - name: string_split
     unsupported: True
+  - name: starts_with
+    local_name: "startswith"
+    required_options:
+      case_sensitivity: CASE_SENSITIVE
+  - name: ends_with
+    local_name: "endswith"
+    required_options:
+      case_sensitivity: CASE_SENSITIVE
+  - name: contains
+    required_options:
+      case_sensitivity: CASE_SENSITIVE
   - name: ln
     required_options:
       on_log_zero: ERROR

--- a/dialects/sqlite.yaml
+++ b/dialects/sqlite.yaml
@@ -260,6 +260,12 @@ scalar_functions:
     unsupported: True
   - name: string_split
     unsupported: True
+  - name: starts_with
+    unsupported: True
+  - name: ends_with
+    unsupported: True
+  - name: contains
+    unsupported: True
   - name: ln
     required_options:
       on_log_zero: NAN

--- a/dialects/velox_presto.yaml
+++ b/dialects/velox_presto.yaml
@@ -799,6 +799,12 @@ scalar_functions:
   - name: string_split
     local_name: "split"
     unsupported: True
+  - name: starts_with
+    unsupported: True
+  - name: ends_with
+    unsupported: True
+  - name: contains
+    unsupported: True
   - name: ln
     required_options:
       on_log_zero: MINUS_INFINITY


### PR DESCRIPTION
* Added test case for starts_with, ends_with and contains based on Snowflake behavior
* left, right, substring are not supported because of behavior difference in unicode
